### PR TITLE
Performance update for Capitalize.

### DIFF
--- a/src/NetBox/System/StringExtensions.cs
+++ b/src/NetBox/System/StringExtensions.cs
@@ -293,15 +293,11 @@
       /// </summary>
       public static string Capitalize(this string s)
       {
-         if (s == null) return null;
-         var b = new StringBuilder();
-
-         for (int i = 0; i < s.Length; i++)
-         {
-            b.Append(i == 0 ? char.ToUpper(s[i]) : char.ToLower(s[i]));
-         }
-
-         return b.ToString();
+         if (s == null || s.Length == 0) return s;
+         if (s.Length == 1) return s.ToUpper();
+         char[] c = s.ToLower().ToCharArray();
+         c[0] = char.ToUpper(c[0]);
+         return new string(c);
       }
 
       /// <summary>


### PR DESCRIPTION
A totally unnecessary improvement to the performance, and reduction of memory usage/object creation of the Capitalize function.  See attached file for timing tests.

[CapitalizationTiming.txt](https://github.com/aloneguid/netbox/files/9612331/CapitalizationTiming.txt)

The 4 different cases shown in the file are 

1. StringBuilderImplementation: Original code
2. ToLowerWithCharArray: The code submitted for this PR
3. UnsafeCapitalization: An unsafe implementation of the code submitted for the PR.
4. CapitalizationWithSubstring: A version that safely does the following `return char.ToUpper(s[0]) + s.Substring(1).ToLower();`  This actually performed surprisingly well, but it uses a little more memory than the code in the PR.

